### PR TITLE
Implement a polling file watcher and a sample 'tail -f' tool

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/seedtray/logReader"
+	"github.com/spf13/afero"
+	"io"
+	"log"
+)
+
+// Prints a file's lines and watches for further appends. Similar to tail -f.
+// Each line is printed prefixed by a number which can be used as a starting point on a later call.
+func main() {
+
+	var position = flag.Int64("resume", 0, "Resume from position. By default it starts at the beginning.")
+	flag.Parse()
+	filename := flag.Arg(0)
+
+	watcher := logReader.NewOsPollingFileWatcher(filename)
+	fileUpdates, err := watcher.Start()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fs := afero.NewOsFs()
+	file, err := fs.Open(filename)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	lineReader, err := logReader.NewLineReaderAtPosition(file, *position)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	for {
+		line, position, err := lineReader.ReadLine()
+		if err == nil {
+			fmt.Printf("%10d: %s\n", position, string(line))
+		} else if err == io.EOF {
+			err = <-fileUpdates
+			if err != nil {
+				log.Fatalln(err)
+			}
+		} else {
+			log.Fatalln(err)
+		}
+	}
+}

--- a/fileWatcher.go
+++ b/fileWatcher.go
@@ -1,0 +1,8 @@
+package logReader
+
+type updateSignal error
+
+type FileWatcher interface {
+	Start() (<-chan updateSignal, error)
+	Stop() error
+}

--- a/pollingFileWatcher.go
+++ b/pollingFileWatcher.go
@@ -1,0 +1,70 @@
+package logReader
+
+import (
+	"errors"
+	"github.com/spf13/afero"
+	"time"
+)
+
+type PollingFileWatcher struct {
+	filename string
+	fs       afero.Fs
+	watching bool
+}
+
+var _ FileWatcher = &PollingFileWatcher{}
+
+func NewOsPollingFileWatcher(filename string) *PollingFileWatcher {
+	return &PollingFileWatcher{filename, afero.NewOsFs(), false}
+}
+
+func (pw *PollingFileWatcher) Start() (<-chan updateSignal, error) {
+	if pw.watching {
+		return nil, errors.New("already watching")
+	}
+	updates := make(chan updateSignal)
+	pw.watching = true
+	go pw.watch(updates)
+	return updates, nil
+}
+
+func (pw *PollingFileWatcher) Stop() error {
+	if !pw.watching {
+		return errors.New("not watching")
+	}
+	pw.watching = false
+	return nil
+}
+
+const pollInterval = 1 * time.Millisecond
+
+func (pw *PollingFileWatcher) watch(updates chan updateSignal) {
+	var lastSize int64 = 0
+	lastModTime := time.UnixMilli(0)
+	for {
+		if !pw.watching {
+			close(updates)
+			return
+		}
+		fileInfo, err := pw.fs.Stat(pw.filename)
+		if err != nil {
+			select {
+			case updates <- err:
+			}
+			close(updates)
+			return
+		}
+		currentSize := fileInfo.Size()
+		currentModTime := fileInfo.ModTime()
+		if currentSize != lastSize || !currentModTime.Equal(lastModTime) {
+			select {
+			case updates <- nil:
+			default:
+			}
+			lastSize = currentSize
+			lastModTime = currentModTime
+		} else {
+			time.Sleep(pollInterval)
+		}
+	}
+}

--- a/pollingFileWatcher.go
+++ b/pollingFileWatcher.go
@@ -40,7 +40,7 @@ const pollInterval = 1 * time.Millisecond
 
 func (pw *PollingFileWatcher) watch(updates chan updateSignal) {
 	var lastSize int64 = 0
-	lastModTime := time.UnixMilli(0)
+	lastModTime := time.Unix(0, 0)
 	for {
 		if !pw.watching {
 			close(updates)

--- a/pollingFileWatcher_test.go
+++ b/pollingFileWatcher_test.go
@@ -1,0 +1,67 @@
+package logReader
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestNotifiesOnAppend(t *testing.T) {
+	file, err := TestFs.OpenFile(t.Name(), syscall.O_CREAT|syscall.O_APPEND|syscall.O_SYNC, 0600)
+	if err != nil {
+		t.Error(err)
+	}
+	watcher := PollingFileWatcher{t.Name(), TestFs, false}
+	updates, err := watcher.Start()
+	if err != nil {
+		t.Error(err)
+	}
+	select {
+	case <-updates:
+	case <-time.After(10 * pollInterval):
+		t.Errorf("didn't get initial update from file watcher")
+	}
+	select {
+	case <-updates:
+		t.Errorf("got a second update from watcher without an update")
+	case <-time.After(10 * pollInterval):
+	}
+	if _, err = fmt.Fprintln(file, "An update"); err != nil {
+		t.Error(err)
+	}
+	select {
+	case <-updates:
+	case <-time.After(10 * pollInterval):
+		t.Errorf("watcher didn't signal a file change.")
+	}
+}
+
+func TestSendsErrorIfStatFails(t *testing.T) {
+	_, err := TestFs.OpenFile(t.Name(), syscall.O_CREAT|syscall.O_APPEND|syscall.O_SYNC, 0600)
+	if err != nil {
+		t.Error(err)
+	}
+	watcher := PollingFileWatcher{t.Name(), TestFs, false}
+	updates, err := watcher.Start()
+	if err != nil {
+		t.Error(err)
+	}
+	select {
+	case <-updates:
+	case <-time.After(10 * pollInterval):
+		t.Errorf("didn't get initial update")
+	}
+	if err = TestFs.Remove(t.Name()); err != nil {
+		t.Error(err)
+	}
+	select {
+	case err = <-updates:
+		if err == nil {
+			t.Errorf("didn't receive an expected error")
+		}
+	case <-time.After(10 * pollInterval):
+		t.Errorf("watcher didn't signal a file change.")
+	}
+
+}


### PR DESCRIPTION
A rough interface for a (single) file watcher, and a polling implementation.
Includes a command line tool that uses the watcher and a line reader together, implementing something comparable to `tail -f`.
Note that this PR is linked to #1. I would have waited for merging that one first, but the weekend is short ;)